### PR TITLE
Export to midi

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The Ruby output can then be used to play back the music, for example in Sonic Pi
 ```ruby
 load '<path to your output file from before>'
 
-previous_frame = 1
+previous_frame = 0
 ::SYNTHS.each do |synth|
   current_frame = synth[0]
   frames_to_sleep = current_frame - previous_frame

--- a/README.md
+++ b/README.md
@@ -13,12 +13,27 @@ Commodore 64 sound chip, the SID (Sound Interface Device). Which means that in o
 `.sid` file like it would sound on an actual Commodore 64, you will have to simulate both the
 processor and the sound chip.
 
-This project does not attempt to simulate the SID chip to produce authentic sounds - lots of those
-players already exist - but instead has a very simple implementation that produces data that can be
-used to play back the songs. You know, almost as notes.
+This project does not attempt to produce an authentic playback of the sounds - lots of those
+players already exist - but instead lets you export a Commodore 64 song into a format that lets
+you edit and experiment with the song. Want to change the instruments? Go ahead. Want to take out
+parts of the song and use in other projects? You can do that. Want to just listen to your favourite
+Commodore 64 song played back by a piano? Definitely do that!
 
-Currently the only output format is a Ruby file which defines a list of synths to play at certain
-points in time. This can be used to play back the music in [Sonic Pi](https://sonic-pi.net).
+## Supported Output Formats
+
+### Ruby
+
+You can get a simple Ruby file which defines a list of synths to play at certain points in time.
+This can be used to play back the music in [Sonic Pi](https://sonic-pi.net) (see below), or you
+can write your own little Ruby script to do your own post-processing.
+
+### Midi
+
+If you just want to listen to a `.sid` file, the easiest way is to export to midi file format and
+open the file in a player such as [VLC](https://www.videolan.org/vlc/index.html). However, if you
+want to further edit the result, import the file in a music editor such as GarageBand on a Mac.
+Then you can use all of the tools provided by your music editor to change instruments and rearrange
+the song. 
 
 ## Limitations
 
@@ -46,11 +61,15 @@ Show information, like the author and number of songs in a file:
 
     $ sidtool --info <input file>
 
-Convert the default song from a file to a Ruby list:
+Convert the default song from a `.sid` file to a midi file:
+
+    $ sidtool --out <output file> --format midi <input file>
+
+Convert the default song from a file to a Ruby list (`--format ruby` is the default):
 
     $ sidtool --out <output file> <input file>
 
-The output can then be used to play back the music, for example in Sonic Pi:
+The Ruby output can then be used to play back the music, for example in Sonic Pi:
 
 ```ruby
 load '<path to your output file from before>'

--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
 # Sidtool
 
-Convert Commodore 64 SID music in the form of `.sid` files into other formats! This is still VERY
-much work in progress... the code is ugly and will probably create horrible results for you :-)
+Convert Commodore 64 SID music in the form of `.sid` files into other formats!
 
-Basically, it's a massive hack made for fun and no profit.
-
-The vision, though, is to extract the actual information from `.sid` files, which are files storing
-music for the Commodore 64. This sounds like an easy task.
+Basically, it's a massive hack made for fun and no profit. The vision, though, is to extract the
+actual information from `.sid` files, which are files storing music for the Commodore 64.
 
 `.sid` files contain actual Commodore 64 machine code that writes to registers corresponding to the
 Commodore 64 sound chip, the SID (Sound Interface Device). Which means that in order to play back a
@@ -25,7 +22,7 @@ Commodore 64 song played back by a piano? Definitely do that!
 
 You can get a simple Ruby file which defines a list of synths to play at certain points in time.
 This can be used to play back the music in [Sonic Pi](https://sonic-pi.net) (see below), or you
-can write your own little Ruby script to do your own post-processing.
+can write a Ruby script to do your own post-processing.
 
 ### Midi
 

--- a/bin/sidtool
+++ b/bin/sidtool
@@ -4,6 +4,10 @@ require 'mos6510'
 require 'optparse'
 
 DEFAULT_FRAMES_TO_PROCESS = 15000
+EXPORTERS = {
+  'ruby' => Sidtool::RubyFileWriter,
+  'midi' => Sidtool::MidiFileWriter
+}
 
 params = {}
 OptionParser.new do |parser|
@@ -32,6 +36,10 @@ sid_file = Sidtool::FileReader.read(input_file)
 output_file = params[:out]
 show_info = !!params[:info]
 raise 'Either provide -i or -o, or I have nothing to do!' unless output_file || show_info
+
+format = params[:format] || EXPORTERS.keys.first
+exporter_class = EXPORTERS[format]
+raise "Invalid format: #{format}. Valid formats: #{EXPORTERS.keys.join(', ')}" unless exporter_class
 
 song = params[:song] || sid_file.start_song
 raise 'Song must be at least 1' if song < 1
@@ -75,6 +83,5 @@ if output_file
 
   STDERR.puts("Processed #{frames} frames")
 
-  #Sidtool::RubyFileWriter.new(sid.synths).write_to(output_file)
-  Sidtool::MidiFileWriter.new(sid.synths).write_to(output_file)
+  exporter_class.new(sid.synths).write_to(output_file)
 end

--- a/bin/sidtool
+++ b/bin/sidtool
@@ -10,6 +10,7 @@ OptionParser.new do |parser|
   parser.banner = 'Usage: sidtool [options] <intputfile.sid>'
 
   parser.on('-i', '--info', 'Show file information')
+  parser.on('--format FORMAT', 'Output format, "ruby" (default) or "midi"')
   parser.on('-o', '--out FILENAME', 'Output file (Ruby array)')
   parser.on('-s', '--song NUMBER', Integer, 'Song number to process (defaults to the start song in the file)')
   parser.on('-f', '--frames NUMBER', Integer, "Number of frames to process (default #{DEFAULT_FRAMES_TO_PROCESS})")
@@ -74,11 +75,6 @@ if output_file
 
   STDERR.puts("Processed #{frames} frames")
 
-  File.open(output_file, 'w') do |file|
-    file.puts '::SYNTHS = ['
-    Sidtool::STATE.synths.each do |synth|
-      file.puts synth.to_a.inspect + ','
-    end
-    file.puts ']'
-  end
+  #Sidtool::RubyFileWriter.new(sid.synths).write_to(output_file)
+  Sidtool::MidiFileWriter.new(sid.synths).write_to(output_file)
 end

--- a/bin/sidtool
+++ b/bin/sidtool
@@ -83,5 +83,5 @@ if output_file
 
   STDERR.puts("Processed #{frames} frames")
 
-  exporter_class.new(sid.synths).write_to(output_file)
+  exporter_class.new(sid.synths_for_voices).write_to(output_file)
 end

--- a/lib/sidtool.rb
+++ b/lib/sidtool.rb
@@ -2,6 +2,8 @@ require 'sidtool/version'
 
 module Sidtool
   require 'sidtool/file_reader'
+  require 'sidtool/ruby_file_writer'
+  require 'sidtool/midi_file_writer'
   require 'sidtool/synth'
   require 'sidtool/voice'
   require 'sidtool/sid'

--- a/lib/sidtool/midi_file_writer.rb
+++ b/lib/sidtool/midi_file_writer.rb
@@ -1,0 +1,158 @@
+module Sidtool
+  class MidiFileWriter
+    def initialize(synths)
+      @synths = synths
+    end
+
+    def write_to(path)
+      File.open(path, 'wb') do |file|
+        write_header(file)
+
+        @synths.each_with_index do |synths_for_voice, voice_number|
+          track = [
+            variable_length_quantity(0), time_signature(4, 2, 24, 8),
+            variable_length_quantity(0), key_signature(0, 0),
+            variable_length_quantity(0), program_change(voice_number, 1)
+          ]
+
+          previous_synth = nil
+          synths_for_voice.each do |synth|
+            diff = synth.start_frame - (previous_synth&.start_frame || 0)
+            track << variable_length_quantity(diff)
+            #if previous_synth
+            #  track << note_off(voice_number, previous_synth.tone)
+            #end
+            track << note_on(voice_number, synth.tone)
+            previous_synth = synth
+          end
+
+          track << end_of_track
+
+          write_track(file, track)
+        end
+      end
+    end
+
+    private
+    def write_uint32(file, value)
+      bytes = [(value >> 24) & 255, (value >> 16) & 255, (value >> 8) & 255, value & 255]
+      file << bytes.pack('cccc')
+    end
+
+    def write_uint16(file, value)
+      bytes = [(value >> 8) & 255, value & 255]
+      file << bytes.pack('cc')
+    end
+
+    def write_byte(file, value)
+      bytes = [value & 255]
+      file << bytes.pack('c')
+    end
+
+    def write_header(file)
+      # Type
+      file << 'MThd'
+
+      # Length
+      write_uint32(file, 6)
+
+      # Format
+      write_uint16(file, 1)
+
+      # Number of tracks
+      write_uint16(file, 3)
+
+      # Division
+      # Default tempo is 120 BPM - 120 quarter-notes per minute. Which is 2 quarter-notes per second. If we then define
+      # 25 ticks per quarter-note, we end up with a timing of 50 ticks per second.
+      write_uint16(file, 25)
+    end
+
+    def variable_length_quantity(quantity)
+      seven_bit_segments = []
+      while true
+        seven_bit_segments << (quantity & 127)
+        quantity = quantity >> 7
+        break if quantity == 0
+      end
+      result = seven_bit_segments.reverse.map { |segment| segment | 128 }
+      result[-1] &= 127
+      result
+    end
+
+    def note_on(channel, key)
+      raise "Channel too big: #{channel}" if channel > 15
+      raise "Key is too big: #{key}" if key > 255
+      [
+        0x90 + channel,
+        key,
+        40 # Default velocity
+      ]
+    end
+
+    def note_off(channel, key)
+      raise "Channel too big: #{channel}" if channel > 15
+      raise "Key is too big: #{key}" if key > 255
+      [
+        0x80 + channel,
+        key,
+        40 # Default velocity
+      ]
+    end
+
+    def program_change(channel, program_number)
+      raise "Channel too big: #{channel}" if channel > 15
+      raise "Program number is too big: #{program_number}" if program_number > 255
+      [
+        0xC0 + channel,
+        program_number
+      ]
+    end
+
+    def tempo(units_per_quarter_note)
+      [
+        0xFF, 0x51, 0x03,
+        (units_per_quarter_note >> 16) & 255,
+        (units_per_quarter_note >> 8) & 255,
+        units_per_quarter_note & 255
+      ]
+    end
+
+    def time_signature(numerator, denominator_power_of_two, clocks_per_metronome_click, number_of_32th_nodes_per_24_clocks)
+      [
+        0xFF, 0x58, 0x04,
+        numerator,
+        denominator_power_of_two,
+        clocks_per_metronome_click,
+        number_of_32th_nodes_per_24_clocks
+      ]
+    end
+
+    def key_signature(sharps_or_flats, is_major)
+      [
+        0xFF, 0x59, 0x02,
+        sharps_or_flats,
+        is_major ? 0 : 1
+      ]
+    end
+
+    def end_of_track
+      [
+        0xFF, 0x2F, 0x00
+      ]
+    end
+
+    def write_track(file, track)
+      track_bytes = track.flatten
+
+      # Type
+      file << 'MTrk'
+
+      # Length
+      write_uint32(file, track_bytes.length)
+
+      # Track
+      file << track_bytes.pack('c' * track_bytes.length)
+    end
+  end
+end

--- a/lib/sidtool/midi_file_writer.rb
+++ b/lib/sidtool/midi_file_writer.rb
@@ -1,55 +1,117 @@
 module Sidtool
   class MidiFileWriter
+    # Currently we only support PAL music (50 frames per second)
+    FRAMES_PER_SECOND = 50
+
+    DeltaTime = Struct.new(:time) do
+      def bytes
+        quantity = time
+        seven_bit_segments = []
+        while true
+          seven_bit_segments << (quantity & 127)
+          quantity = quantity >> 7
+          break if quantity == 0
+        end
+        result = seven_bit_segments.reverse.map { |segment| segment | 128 }
+        result[-1] &= 127
+        result
+      end
+    end
+
+    TimeSignature = Struct.new(:numerator, :denominator_power_of_two, :clocks_per_metronome_click, :number_of_32th_nodes_per_24_clocks) do
+      def bytes
+        [
+          0xFF, 0x58, 0x04,
+          numerator,
+          denominator_power_of_two,
+          clocks_per_metronome_click,
+          number_of_32th_nodes_per_24_clocks
+        ]
+      end
+    end
+
+    KeySignature = Struct.new(:sharps_or_flats, :is_major) do
+      def bytes
+        [
+          0xFF, 0x59, 0x02,
+          sharps_or_flats,
+          is_major ? 0 : 1
+        ]
+      end
+    end
+
+    ProgramChange = Struct.new(:channel, :program_number) do
+      def bytes
+        raise "Channel too big: #{channel}" if channel > 15
+        raise "Program number is too big: #{program_number}" if program_number > 255
+        [
+          0xC0 + channel,
+          program_number
+        ]
+      end
+    end
+
+    NoteOn = Struct.new(:channel, :key) do
+      def bytes
+        raise "Channel too big: #{channel}" if channel > 15
+        raise "Key is too big: #{key}" if key > 255
+        [
+          0x90 + channel,
+          key,
+          40 # Default velocity
+        ]
+      end
+    end
+
+    NoteOff = Struct.new(:channel, :key) do
+      def bytes
+        raise "Channel too big: #{channel}" if channel > 15
+        raise "Key is too big: #{key}" if key > 255
+        [
+          0x80 + channel,
+          key,
+          40 # Default velocity
+        ]
+      end
+    end
+
     def initialize(synths)
       @synths = synths
     end
 
     def write_to(path)
+      track = build_track
+
       File.open(path, 'wb') do |file|
         write_header(file)
-
-        @synths.each_with_index do |synths_for_voice, voice_number|
-          track = [
-            variable_length_quantity(0), time_signature(4, 2, 24, 8),
-            variable_length_quantity(0), key_signature(0, 0),
-            variable_length_quantity(0), program_change(voice_number, 1)
-          ]
-
-          previous_synth = nil
-          synths_for_voice.each do |synth|
-            diff = synth.start_frame - (previous_synth&.start_frame || 0)
-            track << variable_length_quantity(diff)
-            if previous_synth
-              track << note_off(voice_number, previous_synth.tone)
-              track << variable_length_quantity(0)
-            end
-            track << note_on(voice_number, synth.tone)
-            previous_synth = synth
-          end
-
-          track << end_of_track
-
-          write_track(file, track)
-        end
+        write_track(file, track)
       end
     end
 
+    def build_track
+      waveforms = [:tri, :saw, :pulse, :noise]
+      frames_and_events = []
+
+      @synths.each_with_index do |synths_for_voice, voice_number|
+        synths_for_voice.each do |synth|
+          channel = voice_number * 4 + (waveforms.index(synth.waveform) || raise("Unknown waveform #{synth.waveform}"))
+          frames_and_events << [synth.start_frame, NoteOn[channel, synth.tone]]
+          duration = [1, (FRAMES_PER_SECOND * (synth.attack + synth.decay + synth.sustain_length)).to_i].max
+          frames_and_events << [synth.start_frame + duration, NoteOff[channel, synth.tone]]
+        end
+      end
+
+      track = []
+      current_frame = 0
+      frames_and_events.sort_by(&:first).each do |frame, event|
+        track << DeltaTime[frame - current_frame]
+        track << event
+        current_frame = frame
+      end
+      track
+    end
+
     private
-    def write_uint32(file, value)
-      bytes = [(value >> 24) & 255, (value >> 16) & 255, (value >> 8) & 255, value & 255]
-      file << bytes.pack('cccc')
-    end
-
-    def write_uint16(file, value)
-      bytes = [(value >> 8) & 255, value & 255]
-      file << bytes.pack('cc')
-    end
-
-    def write_byte(file, value)
-      bytes = [value & 255]
-      file << bytes.pack('c')
-    end
-
     def write_header(file)
       # Type
       file << 'MThd'
@@ -69,82 +131,27 @@ module Sidtool
       write_uint16(file, 25)
     end
 
-    def variable_length_quantity(quantity)
-      seven_bit_segments = []
-      while true
-        seven_bit_segments << (quantity & 127)
-        quantity = quantity >> 7
-        break if quantity == 0
-      end
-      result = seven_bit_segments.reverse.map { |segment| segment | 128 }
-      result[-1] &= 127
-      result
-    end
-
-    def note_on(channel, key)
-      raise "Channel too big: #{channel}" if channel > 15
-      raise "Key is too big: #{key}" if key > 255
-      [
-        0x90 + channel,
-        key,
-        40 # Default velocity
-      ]
-    end
-
-    def note_off(channel, key)
-      raise "Channel too big: #{channel}" if channel > 15
-      raise "Key is too big: #{key}" if key > 255
-      [
-        0x80 + channel,
-        key,
-        40 # Default velocity
-      ]
-    end
-
-    def program_change(channel, program_number)
-      raise "Channel too big: #{channel}" if channel > 15
-      raise "Program number is too big: #{program_number}" if program_number > 255
-      [
-        0xC0 + channel,
-        program_number
-      ]
-    end
-
-    def tempo(units_per_quarter_note)
-      [
-        0xFF, 0x51, 0x03,
-        (units_per_quarter_note >> 16) & 255,
-        (units_per_quarter_note >> 8) & 255,
-        units_per_quarter_note & 255
-      ]
-    end
-
-    def time_signature(numerator, denominator_power_of_two, clocks_per_metronome_click, number_of_32th_nodes_per_24_clocks)
-      [
-        0xFF, 0x58, 0x04,
-        numerator,
-        denominator_power_of_two,
-        clocks_per_metronome_click,
-        number_of_32th_nodes_per_24_clocks
-      ]
-    end
-
-    def key_signature(sharps_or_flats, is_major)
-      [
-        0xFF, 0x59, 0x02,
-        sharps_or_flats,
-        is_major ? 0 : 1
-      ]
-    end
-
-    def end_of_track
-      [
-        0xFF, 0x2F, 0x00
-      ]
-    end
-
     def write_track(file, track)
-      track_bytes = track.flatten
+      track_with_metadata = [
+        DeltaTime[0], TimeSignature[4, 2, 24, 8],
+        DeltaTime[0], KeySignature[0, 0],
+        # Voice 1
+        DeltaTime[0], ProgramChange[0, 1],
+        DeltaTime[0], ProgramChange[1, 2],
+        DeltaTime[0], ProgramChange[2, 3],
+        DeltaTime[0], ProgramChange[3, 4],
+        # Voice 2
+        DeltaTime[0], ProgramChange[4, 1],
+        DeltaTime[0], ProgramChange[5, 2],
+        DeltaTime[0], ProgramChange[6, 3],
+        DeltaTime[0], ProgramChange[7, 4],
+        # Voice 3
+        DeltaTime[0], ProgramChange[8, 1],
+        DeltaTime[0], ProgramChange[9, 2],
+        DeltaTime[0], ProgramChange[10, 3],
+        DeltaTime[0], ProgramChange[11, 4]
+      ] + track
+      track_bytes = track_with_metadata.flat_map(&:bytes)
 
       # Type
       file << 'MTrk'
@@ -154,6 +161,24 @@ module Sidtool
 
       # Track
       file << track_bytes.pack('c' * track_bytes.length)
+
+      # "End of track"
+      file << [0xFF, 0x2F, 0x00].pack('ccc')
+    end
+
+    def write_uint32(file, value)
+      bytes = [(value >> 24) & 255, (value >> 16) & 255, (value >> 8) & 255, value & 255]
+      file << bytes.pack('cccc')
+    end
+
+    def write_uint16(file, value)
+      bytes = [(value >> 8) & 255, value & 255]
+      file << bytes.pack('cc')
+    end
+
+    def write_byte(file, value)
+      bytes = [value & 255]
+      file << bytes.pack('c')
     end
   end
 end

--- a/lib/sidtool/midi_file_writer.rb
+++ b/lib/sidtool/midi_file_writer.rb
@@ -90,12 +90,12 @@ module Sidtool
       end
     end
 
-    def initialize(synths)
-      @synths = synths
+    def initialize(synths_for_voices)
+      @synths_for_voices = synths_for_voices
     end
 
     def write_to(path)
-      tracks = @synths.map { |synths_for_voice| build_track(synths_for_voice) }
+      tracks = @synths_for_voices.map { |synths| build_track(synths) }
 
       File.open(path, 'wb') do |file|
         write_header(file)

--- a/lib/sidtool/midi_file_writer.rb
+++ b/lib/sidtool/midi_file_writer.rb
@@ -1,8 +1,5 @@
 module Sidtool
   class MidiFileWriter
-    # Currently we only support PAL music (50 frames per second)
-    FRAMES_PER_SECOND = 50
-
     DeltaTime = Struct.new(:time) do
       def bytes
         quantity = time

--- a/lib/sidtool/midi_file_writer.rb
+++ b/lib/sidtool/midi_file_writer.rb
@@ -19,9 +19,10 @@ module Sidtool
           synths_for_voice.each do |synth|
             diff = synth.start_frame - (previous_synth&.start_frame || 0)
             track << variable_length_quantity(diff)
-            #if previous_synth
-            #  track << note_off(voice_number, previous_synth.tone)
-            #end
+            if previous_synth
+              track << note_off(voice_number, previous_synth.tone)
+              track << variable_length_quantity(0)
+            end
             track << note_on(voice_number, synth.tone)
             previous_synth = synth
           end

--- a/lib/sidtool/ruby_file_writer.rb
+++ b/lib/sidtool/ruby_file_writer.rb
@@ -1,0 +1,17 @@
+module Sidtool
+  class RubyFileWriter
+    def initialize(synths)
+      @synths = synths
+    end
+
+    def write_to(path)
+      File.open(path, 'w') do |file|
+        file.puts '::SYNTHS = ['
+        @synths.flatten.sort_by(&:start_frame).each do |synth|
+          file.puts synth.to_a.inspect + ','
+        end
+        file.puts ']'
+      end
+    end
+  end
+end

--- a/lib/sidtool/ruby_file_writer.rb
+++ b/lib/sidtool/ruby_file_writer.rb
@@ -1,13 +1,13 @@
 module Sidtool
   class RubyFileWriter
-    def initialize(synths)
-      @synths = synths
+    def initialize(synths_for_voices)
+      @synths_for_voices = synths_for_voices
     end
 
     def write_to(path)
       File.open(path, 'w') do |file|
         file.puts '::SYNTHS = ['
-        @synths.flatten.sort_by(&:start_frame).each do |synth|
+        @synths_for_voices.flatten.sort_by(&:start_frame).each do |synth|
           file.puts synth.to_a.inspect + ','
         end
         file.puts ']'

--- a/lib/sidtool/sid.rb
+++ b/lib/sidtool/sid.rb
@@ -2,7 +2,6 @@ module Sidtool
   class Sid
     def initialize
       @voices = [Voice.new, Voice.new, Voice.new]
-      @synths = []
 
       @frequency_low = @frequency_high = 0
       @pulse_low = @pulse_high = 0
@@ -43,6 +42,10 @@ module Sidtool
 
     def stop!
       @voices.each(&:stop!)
+    end
+
+    def synths
+      [@voices[0].synths, @voices[1].synths, @voices[2].synths]
     end
   end
 end

--- a/lib/sidtool/sid.rb
+++ b/lib/sidtool/sid.rb
@@ -44,8 +44,8 @@ module Sidtool
       @voices.each(&:stop!)
     end
 
-    def synths
-      [@voices[0].synths, @voices[1].synths, @voices[2].synths]
+    def synths_for_voices
+      @voices.map(&:synths)
     end
   end
 end

--- a/lib/sidtool/state.rb
+++ b/lib/sidtool/state.rb
@@ -1,11 +1,9 @@
 module Sidtool
   class State
     attr_accessor :current_frame
-    attr_accessor :synths
 
     def initialize
       @current_frame = 0
-      @synths = []
     end
   end
 end

--- a/lib/sidtool/synth.rb
+++ b/lib/sidtool/synth.rb
@@ -6,6 +6,7 @@ module Sidtool
     attr_accessor :decay
     attr_reader :sustain_length
     attr_accessor :release
+    attr_reader :controls
 
     def initialize(start_frame)
       @start_frame = start_frame

--- a/lib/sidtool/synth.rb
+++ b/lib/sidtool/synth.rb
@@ -4,6 +4,7 @@ module Sidtool
     attr_writer :attack
     attr_writer :decay
     attr_writer :release
+    attr_reader :start_frame
 
     def initialize(start_frame)
       @start_frame = start_frame
@@ -48,8 +49,11 @@ module Sidtool
     end
 
     def to_a
-      tone = sid_frequency_to_nearest_midi(@frequency)
       [@start_frame, tone, @waveform, @attack.round(3), @decay.round(3), @sustain_length.round(3), @release.round(3), @controls]
+    end
+
+    def tone
+      sid_frequency_to_nearest_midi(@frequency)
     end
 
     private

--- a/lib/sidtool/synth.rb
+++ b/lib/sidtool/synth.rb
@@ -1,10 +1,11 @@
 module Sidtool
   class Synth
-    attr_writer :waveform
-    attr_writer :attack
-    attr_writer :decay
-    attr_writer :release
     attr_reader :start_frame
+    attr_accessor :waveform
+    attr_accessor :attack
+    attr_accessor :decay
+    attr_reader :sustain_length
+    attr_accessor :release
 
     def initialize(start_frame)
       @start_frame = start_frame

--- a/lib/sidtool/voice.rb
+++ b/lib/sidtool/voice.rb
@@ -7,41 +7,43 @@ module Sidtool
     attr_writer :control_register
     attr_writer :attack_decay
     attr_writer :sustain_release
+    attr_reader :synths
 
     def initialize
       @frequency_low = @frequency_high = 0
       @pulse_low = @pulse_high = 0
       @attack_decay = @sustain_release = 0
       @control_register = 0
-      @synth = nil
+      @current_synth = nil
+      @synths = []
     end
 
     def finish_frame
       if gate
-        if @synth&.released?
-          @synth.stop!
-          @synth = nil
+        if @current_synth&.released?
+          @current_synth.stop!
+          @current_synth = nil
         end
 
         if frequency > 0
-          if !@synth
-            @synth = Synth.new(STATE.current_frame)
-            STATE.synths << @synth
+          if !@current_synth
+            @current_synth = Synth.new(STATE.current_frame)
+            @synths << @current_synth
           end
-          @synth.frequency = frequency
-          @synth.waveform = waveform
-          @synth.attack = attack
-          @synth.decay = decay
-          @synth.release = release
+          @current_synth.frequency = frequency
+          @current_synth.waveform = waveform
+          @current_synth.attack = attack
+          @current_synth.decay = decay
+          @current_synth.release = release
         end
       else
-        @synth&.release!
+        @current_synth&.release!
       end
     end
 
     def stop!
-      @synth&.stop!
-      @synth = nil
+      @current_synth&.stop!
+      @current_synth = nil
     end
 
     private

--- a/sidtool.gemspec
+++ b/sidtool.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/olefriis/sidtool'
   spec.license       = 'MIT'
 
+  spec.required_ruby_version = '>= 2.3'
+
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end

--- a/spec/midi_file_writer_spec.rb
+++ b/spec/midi_file_writer_spec.rb
@@ -1,21 +1,139 @@
 module Sidtool
   RSpec.describe MidiFileWriter do
-    let(:subject) { MidiFileWriter.new(nil) }
+    # Trying to make frame specification in seconds a bit more readable...
+    ONE_FRAME = 0.02
+    TWO_FRAMES = 0.04
+    THREE_FRAMES = 0.06
+    FOUR_FRAMES = 0.08
+    let(:subject) { MidiFileWriter.new(synths) }
 
-    describe '#variable_length_quantity' do
+    describe '#build_track' do
+      let(:track) { subject.build_track }
+
+      TestSynth = Struct.new(:start_frame, :tone, :waveform, :attack, :decay, :sustain_length, :release)
+
+      context 'with sequential synths for just one voice' do
+        let(:synths) {
+          [
+            [
+              TestSynth[50, 75, :tri, ONE_FRAME, ONE_FRAME, ONE_FRAME, ONE_FRAME],
+              TestSynth[100, 76, :tri, TWO_FRAMES, TWO_FRAMES, TWO_FRAMES, TWO_FRAMES]
+            ],
+            [],
+            []
+          ]
+        }
+
+        it 'places commands sequentially' do
+          expect(track).to eq([
+            MidiFileWriter::DeltaTime[50], MidiFileWriter::NoteOn[0, 75],
+            MidiFileWriter::DeltaTime[3], MidiFileWriter::NoteOff[0, 75],
+            MidiFileWriter::DeltaTime[47], MidiFileWriter::NoteOn[0, 76],
+            MidiFileWriter::DeltaTime[6], MidiFileWriter::NoteOff[0, 76]
+          ])
+        end
+      end
+
+      context 'with different waveforms' do
+        let(:synths) {
+          [
+            [
+              TestSynth[50, 75, :tri, ONE_FRAME, ONE_FRAME, ONE_FRAME, ONE_FRAME],
+              TestSynth[100, 76, :saw, ONE_FRAME, ONE_FRAME, ONE_FRAME, ONE_FRAME],
+              TestSynth[150, 77, :pulse, ONE_FRAME, ONE_FRAME, ONE_FRAME, ONE_FRAME],
+              TestSynth[200, 78, :noise, ONE_FRAME, ONE_FRAME, ONE_FRAME, ONE_FRAME]
+            ],
+            [],
+            []
+          ]
+        }
+
+        it 'uses separate channels' do
+          expect(track).to eq([
+            MidiFileWriter::DeltaTime[50], MidiFileWriter::NoteOn[0, 75],
+            MidiFileWriter::DeltaTime[3], MidiFileWriter::NoteOff[0, 75],
+            MidiFileWriter::DeltaTime[47], MidiFileWriter::NoteOn[1, 76],
+            MidiFileWriter::DeltaTime[3], MidiFileWriter::NoteOff[1, 76],
+            MidiFileWriter::DeltaTime[47], MidiFileWriter::NoteOn[2, 77],
+            MidiFileWriter::DeltaTime[3], MidiFileWriter::NoteOff[2, 77],
+            MidiFileWriter::DeltaTime[47], MidiFileWriter::NoteOn[3, 78],
+            MidiFileWriter::DeltaTime[3], MidiFileWriter::NoteOff[3, 78],
+          ])
+        end
+      end
+
+      context 'with sequential synths for separate voices' do
+        let(:synths) {
+          [
+            [
+              TestSynth[50, 75, :tri, ONE_FRAME, ONE_FRAME, ONE_FRAME, ONE_FRAME],
+              TestSynth[200, 78, :tri, TWO_FRAMES, TWO_FRAMES, TWO_FRAMES, TWO_FRAMES]
+            ],
+            [
+              TestSynth[100, 76, :tri, TWO_FRAMES, TWO_FRAMES, TWO_FRAMES, TWO_FRAMES],
+              TestSynth[250, 79, :tri, THREE_FRAMES, THREE_FRAMES, THREE_FRAMES, THREE_FRAMES]
+            ],
+            [
+              TestSynth[150, 77, :tri, THREE_FRAMES, THREE_FRAMES, THREE_FRAMES, THREE_FRAMES],
+              TestSynth[300, 80, :tri, FOUR_FRAMES, FOUR_FRAMES, FOUR_FRAMES, FOUR_FRAMES]
+            ]
+          ]
+        }
+
+        it 'places commands sequentially and maps to different channels' do
+          expect(track).to eq([
+            MidiFileWriter::DeltaTime[50], MidiFileWriter::NoteOn[0, 75],
+            MidiFileWriter::DeltaTime[3], MidiFileWriter::NoteOff[0, 75],
+            MidiFileWriter::DeltaTime[47], MidiFileWriter::NoteOn[4, 76],
+            MidiFileWriter::DeltaTime[6], MidiFileWriter::NoteOff[4, 76],
+            MidiFileWriter::DeltaTime[44], MidiFileWriter::NoteOn[8, 77],
+            MidiFileWriter::DeltaTime[9], MidiFileWriter::NoteOff[8, 77],
+            MidiFileWriter::DeltaTime[41], MidiFileWriter::NoteOn[0, 78],
+            MidiFileWriter::DeltaTime[6], MidiFileWriter::NoteOff[0, 78],
+            MidiFileWriter::DeltaTime[44], MidiFileWriter::NoteOn[4, 79],
+            MidiFileWriter::DeltaTime[9], MidiFileWriter::NoteOff[4, 79],
+            MidiFileWriter::DeltaTime[41], MidiFileWriter::NoteOn[8, 80],
+            MidiFileWriter::DeltaTime[12], MidiFileWriter::NoteOff[8, 80],
+          ])
+        end
+      end
+
+      context 'with interleaved synths' do
+        let(:synths) {
+          [
+            [TestSynth[50, 75, :tri, ONE_FRAME, ONE_FRAME, ONE_FRAME, ONE_FRAME]],
+            [TestSynth[51, 76, :tri, TWO_FRAMES, TWO_FRAMES, TWO_FRAMES, TWO_FRAMES]],
+            [TestSynth[52, 77, :tri, THREE_FRAMES, THREE_FRAMES, THREE_FRAMES, THREE_FRAMES]]
+          ]
+        }
+
+        it 'interleaves commands' do
+          expect(track).to eq([
+            MidiFileWriter::DeltaTime[50], MidiFileWriter::NoteOn[0, 75],
+            MidiFileWriter::DeltaTime[1], MidiFileWriter::NoteOn[4, 76],
+            MidiFileWriter::DeltaTime[1], MidiFileWriter::NoteOn[8, 77],
+            MidiFileWriter::DeltaTime[1], MidiFileWriter::NoteOff[0, 75],
+            MidiFileWriter::DeltaTime[4], MidiFileWriter::NoteOff[4, 76],
+            MidiFileWriter::DeltaTime[4], MidiFileWriter::NoteOff[8, 77],
+          ])
+        end
+      end
+    end
+
+    describe 'DeltaTime#bytes' do
       it 'returns just the number when below 128' do
-        expect(subject.send(:variable_length_quantity, 0)).to eq([0])
-        expect(subject.send(:variable_length_quantity, 1)).to eq([1])
+        expect(MidiFileWriter::DeltaTime[0].bytes).to eq([0])
+        expect(MidiFileWriter::DeltaTime[1].bytes).to eq([1])
 
-        expect(subject.send(:variable_length_quantity, 126)).to eq([126])
-        expect(subject.send(:variable_length_quantity, 127)).to eq([127])
+        expect(MidiFileWriter::DeltaTime[126].bytes).to eq([126])
+        expect(MidiFileWriter::DeltaTime[127].bytes).to eq([127])
       end
 
       it 'splits up in two bytes when value is above 127' do
-        expect(subject.send(:variable_length_quantity, 128)).to eq([128 + 1, 0])
-        expect(subject.send(:variable_length_quantity, 129)).to eq([128 + 1, 1])
-        expect(subject.send(:variable_length_quantity, 130)).to eq([128 + 1, 2])
-        expect(subject.send(:variable_length_quantity, 192)).to eq([128 + 1, 64])
+        expect(MidiFileWriter::DeltaTime[128].bytes).to eq([128 + 1, 0])
+        expect(MidiFileWriter::DeltaTime[129].bytes).to eq([128 + 1, 1])
+        expect(MidiFileWriter::DeltaTime[130].bytes).to eq([128 + 1, 2])
+        expect(MidiFileWriter::DeltaTime[192].bytes).to eq([128 + 1, 64])
       end
     end
   end

--- a/spec/midi_file_writer_spec.rb
+++ b/spec/midi_file_writer_spec.rb
@@ -1,0 +1,22 @@
+module Sidtool
+  RSpec.describe MidiFileWriter do
+    let(:subject) { MidiFileWriter.new(nil) }
+
+    describe '#variable_length_quantity' do
+      it 'returns just the number when below 128' do
+        expect(subject.send(:variable_length_quantity, 0)).to eq([0])
+        expect(subject.send(:variable_length_quantity, 1)).to eq([1])
+
+        expect(subject.send(:variable_length_quantity, 126)).to eq([126])
+        expect(subject.send(:variable_length_quantity, 127)).to eq([127])
+      end
+
+      it 'splits up in two bytes when value is above 127' do
+        expect(subject.send(:variable_length_quantity, 128)).to eq([128 + 1, 0])
+        expect(subject.send(:variable_length_quantity, 129)).to eq([128 + 1, 1])
+        expect(subject.send(:variable_length_quantity, 130)).to eq([128 + 1, 2])
+        expect(subject.send(:variable_length_quantity, 192)).to eq([128 + 1, 64])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Thinking of adding a `--format` parameter to the tool so that we can choose between Ruby output (the current default) and midi.

Lots of stuff I haven't decided about the level of midi support, but just having the option will add the possibility of loading the music into music editors and start experimenting for real with the SID music!